### PR TITLE
Add admin requirement for creating Categories along with integration test

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -30,7 +30,7 @@ class CategoriesController < ApplicationController
   end
 
   def require_admin
-    if !(logged_in? && current_user.admin?)
+    unless (logged_in? && current_user.admin?)
       flash[:alert] = "Only admins can perform that action"
       redirect_to categories_path
     end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,4 +1,5 @@
 class CategoriesController < ApplicationController
+  before_action :require_admin, except: [:index, :show]
   
   def new
     @category = Category.new
@@ -26,6 +27,13 @@ class CategoriesController < ApplicationController
   
   def category_params
     params.require(:category).permit(:name)
+  end
+
+  def require_admin
+    if !(logged_in? && current_user.admin?)
+      flash[:alert] = "Only admins can perform that action"
+      redirect_to categories_path
+    end
   end
 
 end

--- a/test/controllers/categories_controller_test.rb
+++ b/test/controllers/categories_controller_test.rb
@@ -7,11 +7,15 @@ class CategoriesControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should get new" do
+    @admin_user = User.create(username: "johndoe", email: "john@example.com", password: "password", admin: true)
+    sign_in_as(@admin_user)
     get new_category_url
     assert_response :success
   end
 
   test "should create category" do
+    @admin_user = User.create(username: "johndoe", email: "john@example.com", password: "password", admin: true)
+    sign_in_as(@admin_user)
     assert_difference('Category.count', 1) do
       post categories_url, params: { category: { name: "Travel" } }
     end
@@ -23,6 +27,14 @@ class CategoriesControllerTest < ActionDispatch::IntegrationTest
     @category = Category.create(name: "Sports")
     get category_url(@category)
     assert_response :success
+  end
+
+  test "should not create category if not admin" do
+    assert_no_difference('Category.count') do
+      post categories_url, params: { category: { name: "Travel" } }
+    end
+
+    assert_redirected_to categories_url
   end
 
   # test "should get edit" do

--- a/test/integration/create_category_test.rb
+++ b/test/integration/create_category_test.rb
@@ -1,6 +1,11 @@
 require "test_helper"
 
 class CreateCategoryTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin_user = User.create(username: "johndoe", email: "john@example.com", password: "password", admin: true)
+    sign_in_as(@admin_user)
+  end
+
   test "get new category form and create category" do
     get new_category_path
     assert_response :success

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,4 +10,7 @@ class ActiveSupport::TestCase
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
+  def sign_in_as(user)
+    post login_path, params: { session: { email: user.email, password: "password" } }
+  end
 end


### PR DESCRIPTION
Depends on #91 

- using of `test_helper` to helper function
- add `require_admin` private function in `CategoriesController`
- add only allow admin to create Categories